### PR TITLE
WIP: Added log scale option to scatter plot

### DIFF
--- a/visualizations/scatter_plot/examples/scatter_plot_example.py
+++ b/visualizations/scatter_plot/examples/scatter_plot_example.py
@@ -14,4 +14,4 @@ points = pd.DataFrame([point1, point2])
 page.add_content(ScatterPlot(points, logy=True))
 
 web.add(page)
-web.write_html("./webviz_example", overwrite=True, display=True)
+web.write_html("./webviz_example", overwrite=True, display=False)

--- a/visualizations/scatter_plot/examples/scatter_plot_example.py
+++ b/visualizations/scatter_plot/examples/scatter_plot_example.py
@@ -2,7 +2,7 @@ from webviz import Webviz, Page
 from webviz.page_elements import ScatterPlot
 import pandas as pd
 
-web = Webviz('Scatter Plot Example', theme='equinor')
+web = Webviz('Scatter Plot Example')
 
 page = Page('Scatter Plot')
 

--- a/visualizations/scatter_plot/examples/scatter_plot_example.py
+++ b/visualizations/scatter_plot/examples/scatter_plot_example.py
@@ -1,17 +1,17 @@
 from webviz import Webviz, Page
-from webviz_scatter_plot import ScatterPlot
+from webviz.page_elements import ScatterPlot
 import pandas as pd
 
-web = Webviz('Scatter Plot Example')
+web = Webviz('Scatter Plot Example', theme='equinor')
 
 page = Page('Scatter Plot')
 
 point1 = [10, 15, 13, 17],
-
-point2 = [16, 5, 11, 9]
+point2 = [10, 10e2, 10e3, 10e4]
 
 points = pd.DataFrame([point1, point2])
 
-page.add_content(ScatterPlot(points))
+page.add_content(ScatterPlot(points, logy=True))
+
 web.add(page)
-web.write_html("./webviz_example", overwrite=True, display=False)
+web.write_html("./webviz_example", overwrite=True, display=True)

--- a/visualizations/scatter_plot/webviz_scatter_plot/__init__.py
+++ b/visualizations/scatter_plot/webviz_scatter_plot/__init__.py
@@ -10,11 +10,15 @@ class ScatterPlot(FilteredPlotly):
         horizontal values. Similarly for the `csv` file, where a special column
         named ``index`` will be used for the horizontal values.
     """
-    def __init__(self, *args, **kwargs):
+    def __init__(self, data, logx=False, logy=False, *args, **kwargs):
         super(ScatterPlot, self).__init__(
-            *args,
-            layout={},
+            data,
+            layout={
+                    'xaxis': {'type': 'log' if logx else '-'},
+                    'yaxis': {'type': 'log' if logy else '-'}
+                   },
             config={},
+            *args,
             **kwargs)
 
     def process_data(self, data):


### PR DESCRIPTION
Currently there is no support for exposing the underlying plotly functionality of choosing log scale.

This is a WIP, demonstrating it on the scatter plot. The webviz API, and how it translates into plotly layout,  will depend on the visualization in question. E.g., the scatter plot matrix will need one boolean per column/row in the matrix.