### PR TITLE
Remove plotly modebar buttons

### DIFF
--- a/visualizations/bar_chart/webviz_bar_chart/__init__.py
+++ b/visualizations/bar_chart/webviz_bar_chart/__init__.py
@@ -19,9 +19,7 @@ class BarChart(FilteredPlotly):
                 data,
                 *args,
                 layout={'barmode': barmode},
-                config={'modeBarButtonsToRemove': ['sendDataToCloud',
-                                                   'resetScale2d',
-                                                   'lasso2d']},
+                config={},
                 **kwargs)
 
     def process_data(self, frame):

--- a/visualizations/bar_chart/webviz_bar_chart/__init__.py
+++ b/visualizations/bar_chart/webviz_bar_chart/__init__.py
@@ -19,11 +19,7 @@ class BarChart(FilteredPlotly):
                 data,
                 *args,
                 layout={'barmode': barmode},
-                config={'displaylogo': False,
-                        'modeBarButtonsToRemove': ['sendDataToCloud',
-                                                   'lasso2d',
-                                                   'resetAxes']
-                        },
+                config={'modeBarButtonsToRemove': ['lasso2d']},
                 **kwargs)
 
     def process_data(self, frame):

--- a/visualizations/bar_chart/webviz_bar_chart/__init__.py
+++ b/visualizations/bar_chart/webviz_bar_chart/__init__.py
@@ -19,7 +19,11 @@ class BarChart(FilteredPlotly):
                 data,
                 *args,
                 layout={'barmode': barmode},
-                config={},
+                config={'displaylogo': False,
+                        'modeBarButtonsToRemove': ['sendDataToCloud',
+                                                   'lasso2d',
+                                                   'resetAxes']
+                       },
                 **kwargs)
 
     def process_data(self, frame):

--- a/visualizations/bar_chart/webviz_bar_chart/__init__.py
+++ b/visualizations/bar_chart/webviz_bar_chart/__init__.py
@@ -19,7 +19,9 @@ class BarChart(FilteredPlotly):
                 data,
                 *args,
                 layout={'barmode': barmode},
-                config={'modeBarButtonsToRemove': ['lasso2d']},
+                config={'modeBarButtonsToRemove': ['sendDataToCloud',
+                                                   'resetScale2d',
+                                                   'lasso2d']},
                 **kwargs)
 
     def process_data(self, frame):

--- a/visualizations/bar_chart/webviz_bar_chart/__init__.py
+++ b/visualizations/bar_chart/webviz_bar_chart/__init__.py
@@ -23,7 +23,7 @@ class BarChart(FilteredPlotly):
                         'modeBarButtonsToRemove': ['sendDataToCloud',
                                                    'lasso2d',
                                                    'resetAxes']
-                       },
+                        },
                 **kwargs)
 
     def process_data(self, frame):

--- a/visualizations/plotly/tests/test_filtered_plotly.py
+++ b/visualizations/plotly/tests/test_filtered_plotly.py
@@ -69,7 +69,7 @@ index,data1,data2
         self.assertTrue('sendDataToCloud' in
                         filtered['config']['modeBarButtonsToRemove'])
 
-    def testSendDataToCloudWarning(self):
+    def testModeBarButtonsRemovalWarning(self):
         with warnings.catch_warnings(record=True) as w:
             MockElement(self.data, config={'modeBarButtonsToRemove': []})
 

--- a/visualizations/plotly/tests/test_filtered_plotly.py
+++ b/visualizations/plotly/tests/test_filtered_plotly.py
@@ -73,8 +73,9 @@ index,data1,data2
         with warnings.catch_warnings(record=True) as w:
             MockElement(self.data, config={'modeBarButtonsToRemove': []})
 
-            assert len(w) == 2
-            assert 'required' in str(w[-1].message)
+            self.assertTrue(len(w) == len(FilteredPlotly.DISALLOWED_BUTTONS))
+            for i, button in enumerate(FilteredPlotly.DISALLOWED_BUTTONS):
+                self.assertTrue(button in str(w[i].message))
 
 
 if __name__ == '__main__':

--- a/visualizations/plotly/tests/test_filtered_plotly.py
+++ b/visualizations/plotly/tests/test_filtered_plotly.py
@@ -61,6 +61,13 @@ index,data1,data2
                         for label in labels)
                         for labels in itervalues(filters)))
 
+    def testSendDataToCloudRemoved(self):
+        filtered = MockElement(self.data)
+
+        self.assertTrue('modeBarButtonsToRemove' in filtered['config'])
+        self.assertTrue('sendDataToCloud' in
+                        filtered['config']['modeBarButtonsToRemove'])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/visualizations/plotly/tests/test_filtered_plotly.py
+++ b/visualizations/plotly/tests/test_filtered_plotly.py
@@ -1,5 +1,6 @@
 import unittest
 import pandas as pd
+import warnings
 from pandas.compat import StringIO
 from six import itervalues
 
@@ -67,6 +68,13 @@ index,data1,data2
         self.assertTrue('modeBarButtonsToRemove' in filtered['config'])
         self.assertTrue('sendDataToCloud' in
                         filtered['config']['modeBarButtonsToRemove'])
+
+    def testSendDataToCloudWarning(self):
+        with warnings.catch_warnings(record=True) as w:
+            MockElement(self.data, config={'modeBarButtonsToRemove': []})
+
+            assert len(w) == 2
+            assert 'required' in str(w[-1].message)
 
 
 if __name__ == '__main__':

--- a/visualizations/plotly/webviz_plotly/__init__.py
+++ b/visualizations/plotly/webviz_plotly/__init__.py
@@ -17,20 +17,28 @@ env = jinja2.Environment(
 class Plotly(JSONPageElement):
     """
     Plotly page element. Arguments are the same as ``plotly.plot()`` from
-    `plotly.js`. See https://plot.ly/javascript/ for usage.
+    `plotly.js`. See https://plot.ly/javascript/ for usage. (note that
+
+    .. note::
+
+       :class:`Plotly` will not allow the modebarbuttons in
+       :const:`DISALLOWED_BUTTONS`, as these are not useful for
+       the visualizations implemented in webviz.
+
     """
+
+    DISALLOWED_BUTTONS = ['sendDataToCloud', 'resetScale2d']
+
     def __init__(self, data, layout={}, config={}):
         super(Plotly, self).__init__()
 
         if 'displaylogo' not in config:
             config['displaylogo'] = False
 
-        disallowed_buttons = ['sendDataToCloud', 'resetScale2d']
-
         if 'modeBarButtonsToRemove' not in config:
-            config['modeBarButtonsToRemove'] = disallowed_buttons
+            config['modeBarButtonsToRemove'] = Plotly.DISALLOWED_BUTTONS
         else:
-            for button in disallowed_buttons:
+            for button in Plotly.DISALLOWED_BUTTONS:
                 if button not in config['modeBarButtonsToRemove']:
                     config['modeBarButtonsToRemove'].append(button)
                     warnings.warn('Including {} required.'.format(button),

--- a/visualizations/plotly/webviz_plotly/__init__.py
+++ b/visualizations/plotly/webviz_plotly/__init__.py
@@ -20,6 +20,15 @@ class Plotly(JSONPageElement):
     """
     def __init__(self, data, layout={}, config={}):
         super(Plotly, self).__init__()
+
+        config['displaylogo'] = False
+
+        if 'modeBarButtonsToRemove' not in config:
+            config['modeBarButtonsToRemove'] = []
+
+        config['modeBarButtonsToRemove'] += ['sendDataToCloud',
+                                             'resetScale2d']
+
         self['data'] = data
         self['config'] = config
         self['layout'] = layout

--- a/visualizations/plotly/webviz_plotly/__init__.py
+++ b/visualizations/plotly/webviz_plotly/__init__.py
@@ -4,6 +4,7 @@ from webviz import JSONPageElement
 from abc import ABCMeta, abstractmethod
 import pandas as pd
 from six import iteritems
+import warnings
 
 env = jinja2.Environment(
     loader=jinja2.PackageLoader('webviz_plotly', 'templates'),
@@ -21,13 +22,19 @@ class Plotly(JSONPageElement):
     def __init__(self, data, layout={}, config={}):
         super(Plotly, self).__init__()
 
-        config['displaylogo'] = False
+        if 'displaylogo' not in config:
+            config['displaylogo'] = False
+
+        disallowed_buttons = ['sendDataToCloud', 'resetScale2d']
 
         if 'modeBarButtonsToRemove' not in config:
-            config['modeBarButtonsToRemove'] = []
-
-        config['modeBarButtonsToRemove'] += ['sendDataToCloud',
-                                             'resetScale2d']
+            config['modeBarButtonsToRemove'] = disallowed_buttons
+        else:
+            for button in disallowed_buttons:
+                if button not in config['modeBarButtonsToRemove']:
+                    config['modeBarButtonsToRemove'].append(button)
+                    warnings.warn('Including {} required.'.format(button),
+                                  Warning)
 
         self['data'] = data
         self['config'] = config

--- a/visualizations/plotly/webviz_plotly/__init__.py
+++ b/visualizations/plotly/webviz_plotly/__init__.py
@@ -17,7 +17,7 @@ env = jinja2.Environment(
 class Plotly(JSONPageElement):
     """
     Plotly page element. Arguments are the same as ``plotly.plot()`` from
-    `plotly.js`. See https://plot.ly/javascript/ for usage. (note that
+    `plotly.js`. See https://plot.ly/javascript/ for usage.
 
     .. note::
 


### PR DESCRIPTION
Resolves #75.

- Button for upload to external Plotly server for modification of plot should be turned off for all plots. The associated button for reseting axis to settings stored in the cloud also removed.