### PR TITLE
fix: use relative paths when indexing files for import

### DIFF
--- a/core/tests/test_utils.py
+++ b/core/tests/test_utils.py
@@ -1,0 +1,250 @@
+import unittest
+from mock import patch, MagicMock, Mock
+from jinja2 import Environment, DictLoader, nodes
+
+from webviz._utils import (
+    get_page_elements,
+    get_full_path,
+    get_relative_path,
+    get_page,
+    get_template_arguments,
+    get_element,
+    dir_contains_md_file
+)
+
+
+class TestWebviz(unittest.TestCase):
+
+    def test_get_page_elements(self):
+        '''
+            should return a dict containing
+            all entry points from pkg_resources
+        '''
+        entry_point_1 = Mock()
+        entry_point_1.configure_mock(name='entry_point_name_1')
+        entry_point_1.load.return_value = 'entry_point_load_value_1'
+
+        entry_point_2 = Mock()
+        entry_point_2.configure_mock(name='entry_point_name_2')
+        entry_point_2.load.return_value = 'entry_point_load_value_2'
+
+        pkg_patch = patch('pkg_resources.iter_entry_points', return_value=[
+            entry_point_1, entry_point_2
+        ])
+        pkg_patch.start()
+        self.assertEqual(
+            get_page_elements(),
+            {
+                'entry_point_name_1': 'entry_point_load_value_1',
+                'entry_point_name_2': 'entry_point_load_value_2'
+            }
+        )
+        pkg_patch.stop()
+
+    def test_get_page_should_return_web_index(self):
+        '''
+            Should return web.index if given filename
+            refers to the top level index.md
+        '''
+        web = Mock()
+        web.configure_mock(index='web_index')
+        page_patch = patch('webviz._utils.Page', return_value='page_name')
+        page_patch.start()
+
+        self.assertEqual(
+            get_page(
+                filename='index.md',
+                name='name',
+                web=web,
+            ),
+            'web_index'
+        )
+        page_patch.stop()
+
+    def test_get_page_should_return_page_of_name(self):
+        '''
+            Should return Page(name) if given filename
+            does not refer to the top level index.md
+        '''
+        web = Mock()
+        web.configure_mock(index='web_index')
+        page_patch = patch('webviz._utils.Page', return_value='page_name')
+        page_patch.start()
+        self.assertEqual(
+            get_page(
+                filename='not_index.md',
+                name='name',
+                web=web,
+            ),
+            'page_name'
+        )
+        page_patch.stop()
+
+    def test_get_full_path(self):
+        self.assertEqual(
+            get_full_path('user/dir/dir', './file.md'),
+            'user/dir/dir/file.md'
+        )
+
+        self.assertEqual(
+            get_full_path('user/dir/dir', '../file.md'),
+            'user/dir/file.md'
+        )
+
+        self.assertEqual(
+            get_full_path('user/dir/dir', './sub_dir/file.md'),
+            'user/dir/dir/sub_dir/file.md'
+        )
+
+    def test_get_relative_path(self):
+        cwd_patch = patch('os.getcwd', return_value='user')
+        cwd_patch.start()
+        self.assertEqual(
+            get_relative_path(
+                original_path='./index.html',
+                root='user/dir/sub_dir',
+                top_directory='user/dir'
+            ),
+            'sub_dir/index.html'
+        )
+        cwd_patch.stop()
+
+    def test_get_template_arguments_should_return_arguments(self):
+        '''
+            get_template_arguments should return arguments if given
+            template_node containing it
+        '''
+        template_node = nodes.Template([
+            nodes.Output(
+                [nodes.Call(
+                    nodes.Name(
+                        'node_name',
+                        'load'
+                    ),
+                    [
+                        nodes.Const('ChartType'),
+                        nodes.Const('./file_1.csv'),
+                        nodes.Const('./file_2.csv')
+                    ],
+                    [
+                        nodes.Keyword('flag', nodes.Const(True)),
+                        nodes.Keyword('list', nodes.List(
+                            [
+                                nodes.Const('item_1'),
+                                nodes.Const('item_2')
+                            ]
+                        ))
+                    ],
+                    None,
+                    None
+                )]
+            )
+        ])
+        cwd_patch = patch('os.getcwd', return_value='root')
+        cwd_patch.start()
+        self.assertEqual(
+            get_template_arguments(
+                template_node=template_node,
+                root='root',
+                top_directory='root'
+            ),
+            (
+                'ChartType',
+                ('file_1.csv', 'file_2.csv'),
+                {'flag': True, 'list': ['item_1', 'item_2']}
+            )
+        )
+        cwd_patch.stop()
+
+    def test_get_template_arguments_should_return_none(self):
+        '''
+            get_template_arguments should return None if
+            template_node's body is empty
+        '''
+        self.assertIsNone(
+            get_template_arguments(
+                template_node=nodes.Template([]),
+                root='.',
+                top_directory='.'
+            )
+        )
+
+    def test_get_element_should_return_element(self):
+        '''
+            get_element should return element if template_arguments
+            match page_elements
+        '''
+        element_mock_1 = Mock(return_value='element_1')
+        element_mock_2 = Mock(return_value='element_2')
+        page_elements = {
+            'el_1': element_mock_1,
+            'el_2': element_mock_2
+        }
+        name = 'el_1'
+        args = ('argument_1', 'argument_2')
+        kwargs = {
+            'key_1': 'value_1',
+            'key_2': 'value_2'
+        }
+        template_arguments = (name, args, kwargs)
+        element = get_element(
+            page_elements=page_elements,
+            template_arguments=template_arguments
+        )
+        self.assertEqual(element, 'element_1')
+        element_mock_1.assert_called_once_with(*args, **kwargs)
+        element_mock_2.assert_not_called()
+
+    def test_get_element_should_return_none(self):
+        '''
+            get_element should return None if given template_arguments
+            are None
+        '''
+        element_mock_1 = Mock(return_value='element_1')
+        element_mock_2 = Mock(return_value='element_2')
+        page_elements = {
+            'el_1': element_mock_1,
+            'el_2': element_mock_2
+        }
+        self.assertIsNone(
+            get_element(
+                page_elements=page_elements,
+                template_arguments=None
+            )
+        )
+        element_mock_1.assert_not_called()
+        element_mock_2.assert_not_called()
+
+    def test_dir_contains_md_file_returns_true(self):
+        '''
+            dir_contains_md_file should return True if given dir contains
+            a .md file
+        '''
+        listdir_patch = patch('os.listdir', return_value=[
+            'readme.txt',
+            'index.md',
+        ])
+        listdir_patch.start()
+        self.assertTrue(
+            dir_contains_md_file('.')
+        )
+        listdir_patch.stop()
+
+    def test_dir_contains_md_file_returns_false(self):
+        '''
+            dir_contains_md_file should return False if given dir
+            does not contain a .md file
+        '''
+        listdir_patch = patch('os.listdir', return_value=[
+            'readme.txt',
+            'bucket_list.txt',
+        ])
+        listdir_patch.start()
+        self.assertFalse(
+            dir_contains_md_file('.')
+        )
+        listdir_patch.stop()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/core/webviz/_utils.py
+++ b/core/webviz/_utils.py
@@ -1,0 +1,109 @@
+import os
+import pkg_resources
+import markdown
+
+from ._webviz import Page
+from ._html import Html
+
+
+def get_page_elements():
+    page_elements = {}
+    for entry_point in pkg_resources.iter_entry_points('webviz_page_elements'):
+        page_elements[entry_point.name] = entry_point.load()
+    return page_elements
+
+
+def get_html(env, full_file_name, element):
+    untemplated_markdown = ''
+    markdown_template = env.get_template(full_file_name)
+    if element is None:
+        untemplated_markdown = markdown_template.render()
+    else:
+        template = element.get_template()
+        untemplated_markdown = markdown_template.render(
+            page_element=lambda name, *args, **kwargs: template.render(
+                element=element))
+    html = Html(markdown.markdown(
+        untemplated_markdown,
+        extensions=[
+            'markdown.extensions.tables',
+            'markdown.extensions.codehilite'
+        ]
+    ))
+    if element is not None:
+        for js in element.get_js_dep():
+            html.add_js_dep(js)
+        for css in element.get_css_dep():
+            html.add_css_dep(css)
+    html.add_css_dep(
+        os.path.join(
+            os.path.dirname(__file__),
+            'resources',
+            'css',
+            'codehilite.css')
+    )
+    return html
+
+
+def get_page(filename, name, web):
+    if filename == 'index.md':
+        return web.index
+    else:
+        return Page(name)
+
+
+def get_full_path(root, original_path):
+    full_path = os.path.join(root, original_path)
+    return os.path.normpath(full_path)
+
+
+def get_relative_path(original_path, root, top_directory):
+    return os.path.relpath(
+        get_full_path(root=root, original_path=original_path),
+        top_directory
+    )
+
+
+def get_template_node(env, full_file_name):
+    template_source = env.loader.get_source(env, full_file_name)
+    return env.parse(template_source[0])
+
+
+def get_template_arguments(template_node, root, top_directory):
+    try:
+        body = template_node.body[0]
+        for node in body.nodes:
+            try:
+                arguments = node.args
+                name = arguments[0].value
+                args = tuple(map(lambda arg: get_relative_path(
+                    original_path=arg.value,
+                    root=root,
+                    top_directory=top_directory
+                ), node.args[1:]))
+                kwargs = {}
+                for kwarg in node.kwargs:
+                    try:
+                        items = kwarg.value.items
+                        kwargs[kwarg.key] = list(map(lambda k: k.value, items))
+                    except AttributeError:
+                        kwargs[kwarg.key] = kwarg.value.value
+                return (name, args, kwargs)
+            except AttributeError:
+                pass
+    except IndexError:
+        return None
+
+
+def get_element(page_elements, template_arguments):
+    if template_arguments is None:
+        return None
+    name, args, kwargs = template_arguments
+    return page_elements[name](*args, **kwargs)
+
+
+def dir_contains_md_file(dir):
+    for f in os.listdir(dir):
+        if f.endswith('.md'):
+            return True
+    return False

--- a/core/webviz/_webviz_writer.py
+++ b/core/webviz/_webviz_writer.py
@@ -4,6 +4,7 @@ import re
 import shutil
 from uuid import uuid4
 from six import itervalues
+from past.builtins import basestring
 
 
 class WebvizWriter(object):
@@ -164,7 +165,7 @@ class WebvizWriter(object):
             if not os.path.exists(dest):
                 os.makedirs(dest)
 
-            if isinstance(src_file, str):
+            if isinstance(src_file, basestring):
                 target_name = path.basename(src_file)
                 shutil.copy(src_file, dest)
             else:

--- a/visualizations/fan_chart/webviz_fan_chart/__init__.py
+++ b/visualizations/fan_chart/webviz_fan_chart/__init__.py
@@ -2,6 +2,7 @@ from webviz_plotly import FilteredPlotly
 import pandas as pd
 import matplotlib.cm as cm
 import math
+from past.builtins import basestring
 
 color_scheme = cm.get_cmap('Set1')
 
@@ -154,7 +155,7 @@ class FanChart(FilteredPlotly):
         that will determine the size of the marker (in height)
     """
     def __init__(self, data, observations=None, *args, **kwargs):
-        if isinstance(observations, str):
+        if isinstance(observations, basestring):
             self.observations = pd.read_csv(observations)
         else:
             self.observations = observations

--- a/visualizations/pie_chart/webviz_pie_chart/__init__.py
+++ b/visualizations/pie_chart/webviz_pie_chart/__init__.py
@@ -1,6 +1,7 @@
 from webviz_plotly import Plotly
 import pandas as pd
 import math
+from past.builtins import basestring
 
 
 class PieChart(Plotly):
@@ -14,7 +15,7 @@ class PieChart(Plotly):
     """
     def __init__(self, data, num_per_row=4):
         frame = data
-        if isinstance(data, str):
+        if isinstance(data, basestring):
             frame = pd.read_csv(data)
         frame = frame.copy()
 

--- a/visualizations/scatter_plot_matrix/webviz_scatter_plot_matrix/__init__.py
+++ b/visualizations/scatter_plot_matrix/webviz_scatter_plot_matrix/__init__.py
@@ -2,6 +2,7 @@ from webviz_plotly import Plotly
 import pandas as pd
 import matplotlib.cm as cm
 import numbers
+from past.builtins import basestring
 
 color_scheme = cm.get_cmap('Set1')
 
@@ -105,7 +106,7 @@ class ScatterPlotMatrix(Plotly):
         `name` is used to distinguish points.
     """
     def __init__(self, data):
-        if isinstance(data, str):
+        if isinstance(data, basestring):
             self.data = validate_data_format(pd.read_csv(data))
         else:
             self.data = data


### PR DESCRIPTION
This fixes a bug where files were not imported from the same depth level as the file referring to them.
It also contains a refactor where some code is moved from the global scope.