### PR TITLE
WIP: Add labels + flip yaxis on tornado plot

### DIFF
--- a/visualizations/tornado_plot/examples/tornado_plot_example.py
+++ b/visualizations/tornado_plot/examples/tornado_plot_example.py
@@ -36,4 +36,4 @@ plot.add_annotation(
         text='label')
 page.add_content(plot)
 web.add(page)
-web.write_html("./webviz_example", overwrite=True, display=True)
+web.write_html("./webviz_example", overwrite=True, display=False)

--- a/visualizations/tornado_plot/examples/tornado_plot_example.py
+++ b/visualizations/tornado_plot/examples/tornado_plot_example.py
@@ -6,16 +6,26 @@ web = Webviz('Tornado Plot Example')
 
 page = Page('Tornado Plot')
 
-high = [0.8, 1, 0.3, 0.4]
-
-low = [0.5, -0.7, -.5, -0.1]
-
 index = ['A', 'B', 'C', 'D']
 
-bars = pd.DataFrame(
-    {'low': low, 'high': high},
-    index=index
-)
+low = [0.5, -0.7, -.5, -0.1]
+high = [0.8, 1, 0.3, 0.4]
+
+leftlabel = ['Left label A',
+             'Left label B',
+             None,
+             'Left label D']
+
+rightlabel = ['Right label A',
+              None,
+              'Right label C',
+              'Right label D']
+
+bars = pd.DataFrame({'low': low,
+                     'high': high,
+                     'leftlabel': leftlabel,
+                     'rightlabel': rightlabel},
+                    index=index)
 
 plot = TornadoPlot(bars)
 plot.add_annotation(
@@ -26,4 +36,4 @@ plot.add_annotation(
         text='label')
 page.add_content(plot)
 web.add(page)
-web.write_html("./webviz_example", overwrite=True, display=False)
+web.write_html("./webviz_example", overwrite=True, display=True)

--- a/visualizations/tornado_plot/webviz_tornado_plot/__init__.py
+++ b/visualizations/tornado_plot/webviz_tornado_plot/__init__.py
@@ -37,7 +37,6 @@ class TornadoPlot(FilteredPlotly):
                 }
             }
         }
-
         high_bars = {
             'type': 'bar',
             'name': 'high',
@@ -57,7 +56,6 @@ class TornadoPlot(FilteredPlotly):
         for index, row in data.iterrows():
             high_bars['y'].append(index)
             low_bars['y'].append(index)
-
             if row['high'] > 0:
                 base = max(0, row['low'])
                 high_bars['x'].append(row['high'] - base)

--- a/visualizations/tornado_plot/webviz_tornado_plot/__init__.py
+++ b/visualizations/tornado_plot/webviz_tornado_plot/__init__.py
@@ -15,7 +15,8 @@ class TornadoPlot(FilteredPlotly):
             layout={
                 'barmode': 'relative',
                 'showlegend': False,
-                'yaxis': {'automargin': True}
+                'yaxis': {'automargin': True,
+                          'autorange': 'reversed'}
                 },
             config={},
             **kwargs)
@@ -36,6 +37,7 @@ class TornadoPlot(FilteredPlotly):
                 }
             }
         }
+
         high_bars = {
             'type': 'bar',
             'name': 'high',
@@ -55,6 +57,7 @@ class TornadoPlot(FilteredPlotly):
         for index, row in data.iterrows():
             high_bars['y'].append(index)
             low_bars['y'].append(index)
+
             if row['high'] > 0:
                 base = max(0, row['low'])
                 high_bars['x'].append(row['high'] - base)
@@ -70,5 +73,10 @@ class TornadoPlot(FilteredPlotly):
             else:
                 low_bars['x'].append(0)
                 low_bars['base'].append(row['low'])
+
+        if 'leftlabel' in data:
+            low_bars['text'] = data['leftlabel'].fillna('').tolist()
+        if 'rightlabel' in data:
+            high_bars['text'] = data['rightlabel'].fillna('').tolist()
 
         return [low_bars, high_bars]


### PR DESCRIPTION
##### Description of Change

Resolves #84. In addition, it flips the `y` axis of the tornado plot such that it visually honors the row order of the input `pandas.Dataframe`.

The labels are given as optional columns `leftlabel` and `rightlabel` in the input dataframe. If not given, labels will not be added to the plotly plot. Row items in `leftlabel`/`rightlabel` can be `None`, if labels are applicable for some sensitivities in the plot, but not all.

![image](https://user-images.githubusercontent.com/31612826/45881696-3a9a1080-bdac-11e8-898b-32dbe0efda32.png)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and it is linked to an issue
- [x] `make test` and `make lint` passes
- [ ] tests are changed or added
- [ ] relevant documentation is changed or added

Tests and documentation will be extended if implementation choice overall looks ok.
