### PR TITLE
Fix: make plots responsive

### DIFF
--- a/visualizations/plotly/package.json
+++ b/visualizations/plotly/package.json
@@ -12,7 +12,7 @@
   "author": "Equinor ASA",
   "license": "LGPL-3.0",
   "dependencies": {
-    "plotly.js-dist": "^1.39.1"
+    "plotly.js-dist": "^1.41.3"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/visualizations/plotly/tests/test_webviz_plotly.py
+++ b/visualizations/plotly/tests/test_webviz_plotly.py
@@ -1,0 +1,30 @@
+import unittest
+import pandas as pd
+from pandas.compat import StringIO
+
+from webviz_plotly import Plotly
+
+
+class TestWebvizPlotly(unittest.TestCase):
+    def setUp(self):
+        self.data = pd.DataFrame(
+            {
+                'data1': [1, 2],
+                'data2': [3, 4]
+            }
+        )
+        self.test_csv = StringIO(
+            '''
+            index,data1,data2
+            0,1,3
+            1,2,4
+            '''
+        )
+
+    def testPlotsShouldBeResponsive(self):
+        filtered = Plotly(self.data)
+        self.assertTrue(filtered['config']['responsive'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/visualizations/plotly/webviz_plotly/__init__.py
+++ b/visualizations/plotly/webviz_plotly/__init__.py
@@ -32,6 +32,7 @@ class Plotly(JSONPageElement):
     def __init__(self, data, layout={}, config={}):
         super(Plotly, self).__init__()
 
+        config['responsive'] = True
         if 'displaylogo' not in config:
             config['displaylogo'] = False
 


### PR DESCRIPTION
##### Description of Change
<!--
#77 Plotly based visualizations currently do not resize.

##### Checklist

- [x] PR description included and it is linked to an issue
- [x] `make test` and `make lint` passes
- [x] tests are changed or added

Notes: <!-- One-line Change Summary Here-->
